### PR TITLE
Allow locales through parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ TextInput::make('name')
     ->translatable(),
 ```
 
+## Overwrite locales
+
+If you want to overwrite the locales on a specific field you can set the locales through the second parameter of the `->translatable()` function.
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->label('Name')
+    ->translatable(true, ['en' => 'English', 'nl' => 'Dutch', 'fr' => 'French']),
+```
+
+
 ### Good to know
 
 This package will substitute the original field with a `Filament\Forms\Components\Tabs` component. This component will render the original field for each locale.

--- a/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
+++ b/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
@@ -54,7 +54,7 @@ class FilamentTranslatableFieldsPlugin implements Plugin
     {
         $supportedLocales = $this->getSupportedLocales();
 
-        Field::macro('translatable', function (bool $translatable = true) use ($supportedLocales) {
+        Field::macro('translatable', function (bool $translatable = true, ?array $customLocales = null) use ($supportedLocales) {
             if (!$translatable) {
                 return $this;
             }
@@ -65,7 +65,7 @@ class FilamentTranslatableFieldsPlugin implements Plugin
              */
             $field = $this->getClone();
 
-            $tabs = collect($supportedLocales)
+            $tabs = collect($customLocales ?? $supportedLocales)
                 ->map(function ($label, $key) use ($field) {
                     $locale = is_string($key) ? $key : $label;
 


### PR DESCRIPTION
This makes it possible to overwrite the default locales set from the Filament panel.
Sometimes this is handy, especially when working with dynamic languages.