### PR TITLE
Localized Tab Labels

### DIFF
--- a/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
+++ b/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
@@ -68,6 +68,7 @@ class FilamentTranslatableFieldsPlugin implements Plugin
             $tabs = collect($customLocales ?? $supportedLocales)
                 ->map(function ($label, $key) use ($field, $localeSpecificRules) {
                     $locale = is_string($key) ? $key : $label;
+                    $localeLabel = locale_get_display_name($locale, app()->getLocale()) ?? (is_string($key) ? $label : strtoupper($locale));
 
                     $clone = $field
                         ->getClone()
@@ -85,7 +86,7 @@ class FilamentTranslatableFieldsPlugin implements Plugin
                     }
 
                     return Tabs\Tab::make($locale)
-                        ->label(is_string($key) ? $label : strtoupper($locale))
+                        ->label($localeLabel)
                         ->schema([$clone]);
                 })
                 ->toArray();


### PR DESCRIPTION
Added PHP's locale_get_display_name() function to set the labels of the tabs to the display name of the active language.

We can add an option to make locale TabLabels configurable when registering the panel. Now, we can specify supported locales and enable locale TabLabels like this:
  ```php
  ->plugins([
      FilamentTranslatableFieldsPlugin::make()
          ->supportedLocales([
              'en' => 'English',
              'nl' => 'Dutch',
          ])
          ->localeTabLabels(true),
  ])