### PR TITLE
Disguise when one locale

### DIFF
--- a/config/filament-translatable-fields.php
+++ b/config/filament-translatable-fields.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+     |--------------------------------------------------------------------------
+     | Disguise Without Tabs
+     |--------------------------------------------------------------------------
+     |
+     | When only one locale is registered and this option is enabled,
+     | the Forms\Components\Tabs implementation for translations is hidden.
+     | (The field remains translatable, but without any visible tabs.)
+     |
+     */
+
+    'disguise_when_one_locale_available' => false,
+
+];

--- a/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
+++ b/src/Filament/Plugins/FilamentTranslatableFieldsPlugin.php
@@ -61,14 +61,14 @@ class FilamentTranslatableFieldsPlugin implements Plugin
             if (! $translatable) {
                 return $this;
             }
-        
+
             /**
              * @var Field $field
              * @var Field $this
              */
             $field = $this->getClone();
             $locales = collect($customLocales ?? $supportedLocales);
-        
+
             // ? Disguise if it's only one locale If only one locale, adjust and return the cloned field directly.
             if (config('filament-translatable-fields.disguise_when_one_locale_available') && $locales->count() === 1) {
                 $locale = $locales->first();
@@ -76,33 +76,33 @@ class FilamentTranslatableFieldsPlugin implements Plugin
                     ->name("{$field->getName()}.{$locale}")
                     ->label($field->getLabel())
                     ->statePath("{$field->getStatePath(false)}.{$locale}");
-        
+
                 if ($localeSpecificRules && isset($localeSpecificRules[$locale])) {
                     $clone->rules($localeSpecificRules[$locale]);
                 }
-        
+
                 return $clone;
             }
-        
+
             // ? Otherwise, build a tab for each locale.
             $tabs = $locales->map(function ($label, $key) use ($field, $localeSpecificRules) {
                 $locale = is_string($key) ? $key : $label;
-        
+
                 $clone = $field
                     ->getClone()
                     ->name("{$field->getName()}.{$locale}")
                     ->label($field->getLabel())
                     ->statePath("{$field->getStatePath(false)}.{$locale}");
-        
+
                 if ($localeSpecificRules && isset($localeSpecificRules[$locale])) {
                     $clone->rules($localeSpecificRules[$locale]);
                 }
-        
+
                 return Forms\Components\Tabs\Tab::make($locale)
                     ->label(is_string($key) ? $label : strtoupper($locale))
                     ->schema([$clone]);
             })->toArray();
-        
+
             return Forms\Components\Tabs::make('translations')->tabs($tabs);
         });
     }

--- a/src/FilamentTranslatableFieldsServiceProvider.php
+++ b/src/FilamentTranslatableFieldsServiceProvider.php
@@ -12,15 +12,13 @@ class FilamentTranslatableFieldsServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('filament-translatable-fields')
+            ->hasConfigFile()
             ->hasInstallCommand(function (InstallCommand $command) {
-                $composerFile = file_get_contents(__DIR__ . '/../composer.json');
+                $command->publishConfigFile();
 
-                if ($composerFile) {
-                    $githubRepo = json_decode($composerFile, true)['homepage'] ?? null;
-
-                    if ($githubRepo) {
-                        $command
-                            ->askToStarRepoOnGitHub($githubRepo);
+                if ($composerFile = file_get_contents(__DIR__ . '/../composer.json')) {
+                    if ($githubRepo = json_decode($composerFile, true)['homepage'] ?? null) {
+                        $command->askToStarRepoOnGitHub($githubRepo);
                     }
                 }
             });


### PR DESCRIPTION
I added an edge case for when only one locale is available; in that case, we don't need to show the full tab section. Instead, we simply keep storing and translating using the "default" locale.